### PR TITLE
Allow merging multiple user timelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
-    "resin-mixpanel-client": "^2.6.0",
+    "resin-mixpanel-client": "^2.7.0",
     "resin-universal-ga": "^1.2.2",
     "resin-universal-gosquared": "^0.2.0"
   },

--- a/src/adaptors/mixpanel.js
+++ b/src/adaptors/mixpanel.js
@@ -48,12 +48,12 @@ module.exports = function (options) {
 	var mixpanel = ResinMixpanelClient(token, mixpanelOptions)
 
 	return {
-		login: function(user) {
+		login: function(user, deviceIds) {
 			if (!user) return
 			var methodName = user.$created ? 'signup' : 'login'
 			var mixpanelUser = getMixpanelUser(user)
 
-			return mixpanel[methodName](user.username)
+			return mixpanel[methodName](user.username, deviceIds)
 				.then(function() {
 					// Calling this also ensures that the auto-tracked properties
 					// ($os, $browser, $browser_version, $initial_referrer, $initial_referring_domain)

--- a/src/resin-event-log.js
+++ b/src/resin-event-log.js
@@ -134,7 +134,7 @@ module.exports = function(options) {
 	var eventLog = {
 		userId: null,
 		prefix: prefix,
-		start: function(user, callback) {
+		start: function(user, deviceIds, callback) {
 			if (user) {
 				if (!user.id || !user.username) {
 					return Promise.reject(
@@ -144,7 +144,7 @@ module.exports = function(options) {
 				this.userId = user.id
 			}
 
-			return runForAllAdaptors('login', [ user ], callback)
+			return runForAllAdaptors('login', [ user, deviceIds ], callback)
 		},
 		end: function(callback) {
 			if (!this.userId) {


### PR DESCRIPTION
This change exposes a mixpanel feature to associate multiple
device IDs to one user name.

Depends on https://github.com/balena-io-modules/resin-mixpanel-client/pull/8

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>