### PR TITLE
add: getting started guide logs

### DIFF
--- a/src/resin-event-log.js
+++ b/src/resin-event-log.js
@@ -86,6 +86,7 @@ var EVENTS = {
 	releaseTag: [ 'set', 'create', 'edit', 'delete' ],
 	billing: [ 'paymentInfoUpdate', 'planChange', 'invoiceDownload' ],
 	onboarding: [ 'stepClick', 'whatNextItemClick'],
+	gettingStartedGuide: ['modalShow', 'modalHide', 'modalSkip', 'modalGuideOpen'],
 	page: [ 'visit' ],
 	navigation: ['click'],
 	members: [ 'create', 'edit', 'delete', 'invite' ],


### PR DESCRIPTION
add getting started guide modal events

see: #3455
see: flowdock discussion
Change-type: minor
Signed-off-by: Andrea Rosci <andrear@balena.io>